### PR TITLE
Fix property value normalization for plain string properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,8 +99,13 @@ const concert_to_records = (args, vault) => {
         // - `entry._source.properties[propery]`
         const properties = entry._source.p || entry._source.properties;
         for (const k in properties) {
-          if (!properties[k].value === undefined) continue;
-          properties[k] = properties[k].value;
+          if (
+            properties[k] &&
+            typeof properties[k] === "object" &&
+            Object.prototype.hasOwnProperty.call(properties[k], "value")
+          ) {
+            properties[k] = properties[k].value;
+          }
         }
         if (args.info)
           process.stdout.write(


### PR DESCRIPTION
Thank you for your work creating this repository! It was incredibly helpful in migrating my Buttercup vault to another password manager.

My revision fixes the property normalization logic for Buttercup vault entries where values are stored directly under `entry._source.properties[property]`.

The current check uses this condition:

    if (!properties[k].value === undefined) continue;

Because of operator precedence, that condition does not correctly guard against plain string values. For vaults using `entry._source.properties[property]`, this causes fields such as `title`, `username`, `password`, `url`, and `notes` to be overwritten with `undefined`, producing CSV rows where only `Group` is populated.

This change only unwraps `properties[k].value` when the property is an object that actually has a `value` field. Plain string properties are preserved as-is.

I encountered this while converting a Buttercup `.bcup` vault where the exported CSV had the expected number of rows, but all fields except `Group` were blank.
